### PR TITLE
prefixed 'x' to each expandedNodeMap id that isn't a scope id to prev…

### DIFF
--- a/angular-tree-control.js
+++ b/angular-tree-control.js
@@ -95,7 +95,7 @@
                     $scope.expandedNodes = $scope.expandedNodes || [];
                     $scope.expandedNodesMap = {};
                     for (var i=0; i < $scope.expandedNodes.length; i++) {
-                        $scope.expandedNodesMap[""+i] = $scope.expandedNodes[i];
+                        $scope.expandedNodesMap['x'+i] = $scope.expandedNodes[i];
                     }
                     $scope.parentScopeOfTree = $scope.$parent;
 
@@ -258,7 +258,7 @@
                                     }
                                 }
                                 if (!found)
-                                    newExpandedNodesMap[notFoundIds++] = newExNode;
+                                    newExpandedNodesMap['x' + notFoundIds++] = newExNode;
                             });
                             scope.expandedNodesMap = newExpandedNodesMap;
                         });
@@ -298,7 +298,7 @@
                         angular.forEach(scope.expandedNodesMap, function (node, id) {
                             if (scope.options.equality(node, scope.node)) {
                                 scope.expandedNodesMap[scope.$id] = scope.node;
-                                scope.expandedNodesMap[id] = undefined;
+                                scope.expandedNodesMap['x'+id] = undefined;
                             }
                         });
                     }


### PR DESCRIPTION
…ent clashes
